### PR TITLE
Add status API endpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# How to run
+npm install
+npm run dev -- --port=3000
+
+# How to test
+curl http://localhost:3000/status

--- a/app/api/status/route.ts
+++ b/app/api/status/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  return new Response('OK');
+}


### PR DESCRIPTION
## Summary
- document app run instructions in `AGENTS.md`
- add `/status` API route for health checks

## Testing
- `npm install` *(fails: registry access blocked)*
- `npm run dev -- --port=3000` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68622f0c521083309cd790d48147bcd6